### PR TITLE
Issue #26 Add endpoint to retrieve a review's logs

### DIFF
--- a/lognition-quarkus/src/main/java/com/redsaz/lognition/view/ReviewsResource.java
+++ b/lognition-quarkus/src/main/java/com/redsaz/lognition/view/ReviewsResource.java
@@ -21,6 +21,7 @@ import com.redsaz.lognition.api.ReviewsService;
 import com.redsaz.lognition.api.labelselector.LabelSelectorExpression;
 import com.redsaz.lognition.api.labelselector.LabelSelectorExpressionFormatter;
 import com.redsaz.lognition.api.labelselector.LabelSelectorSyntaxException;
+import com.redsaz.lognition.api.model.Log;
 import com.redsaz.lognition.api.model.Review;
 import com.redsaz.lognition.services.LabelSelectorParser;
 import java.net.URI;
@@ -130,6 +131,14 @@ public class ReviewsResource {
     public Response deleteReview(@PathParam("id") long id) {
         reviewsSrv.delete(id);
         return Response.status(Status.NO_CONTENT).build();
+    }
+
+    @GET
+    @Path("{id}/logs")
+    @Produces({LognitionMediaType.LOGBRIEF_V1_JSON, MediaType.APPLICATION_JSON})
+    public Response listLogs(@PathParam("id") long id) {
+        List<Log> logs = reviewsSrv.getReviewLogs(id);
+        return Response.ok(logs).build();
     }
 
     private void calculateReviewLogs(Review review) {

--- a/lognition-quarkus/src/test/java/com/redsaz/logntion/ReviewsResourceTest.java
+++ b/lognition-quarkus/src/test/java/com/redsaz/logntion/ReviewsResourceTest.java
@@ -18,6 +18,7 @@ package com.redsaz.logntion;
 import com.redsaz.lognition.api.LognitionMediaType;
 import com.redsaz.lognition.api.LogsService;
 import com.redsaz.lognition.api.ReviewsService;
+import com.redsaz.lognition.api.model.Log;
 import com.redsaz.lognition.api.model.Review;
 import com.redsaz.lognition.view.Sanitizer;
 import io.quarkus.test.junit.QuarkusTest;
@@ -30,6 +31,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -105,6 +107,34 @@ public class ReviewsResourceTest {
                 .then()
                 .statusCode(204);
         verify(reviews).delete(1L);
+    }
+
+    @Test
+    public void testListLogs() {
+        when(reviews.getReviewLogs(anyLong())).thenReturn(
+                Arrays.asList(
+                        new Log(1L, Log.Status.COMPLETE, "test", "Test Name", "test.hsqldb", "Test notes.")
+                )
+        );
+        given()
+                .when().accept(LognitionMediaType.LOGBRIEF_V1_JSON)
+                .get("/reviews/1/logs")
+                .then()
+                .statusCode(200)
+                .body(containsString("\"id\":1"))
+                .body(containsString("test"))
+                .body(containsString("Test Name"));
+    }
+
+    @Test
+    public void testListLogs_empty() {
+        when(reviews.getReviewLogs(anyLong())).thenReturn(Collections.emptyList());
+        given()
+                .when().accept(LognitionMediaType.LOGBRIEF_V1_JSON)
+                .get("/reviews/1/logs")
+                .then()
+                .statusCode(200)
+                .body(containsString("[]"));
     }
 
 }


### PR DESCRIPTION
Adds the endpoint GET /reviews/{id}/logs which retrieves all of the associated logs for a review. The log ids in each entry can be used in the various GET /logs/{id}/... endpoints.